### PR TITLE
Implement task filter

### DIFF
--- a/components/tasks/TaskDashboard.tsx
+++ b/components/tasks/TaskDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { AppUser, TaskCategory } from '../../types';
+import { AppUser, TaskCategory, TaskFilter } from '../../types';
 import { signOutUser } from '../../services/firebaseService';
 import { CategoryTabs } from './CategoryTabs';
 import { TaskForm } from './TaskForm';
@@ -55,6 +55,7 @@ Header.displayName = 'Header';
 
 export const TaskDashboard: React.FC<TaskDashboardProps> = ({ user }) => {
   const [selectedCategory, setSelectedCategory] = useState<TaskCategory>(TASK_CATEGORIES[0]);
+  const [filter, setFilter] = useState<TaskFilter>('all');
   const [showSignOutError, setShowSignOutError] = useState<string | null>(null);
 
   const handleSignOut = async () => {
@@ -78,8 +79,20 @@ export const TaskDashboard: React.FC<TaskDashboardProps> = ({ user }) => {
       <main className="container mx-auto px-4 py-8 flex-grow">
         {showSignOutError && <p className="text-center text-danger mb-4 bg-danger/10 p-3 rounded-lg border border-danger">{showSignOutError}</p>}
         <CategoryTabs selectedCategory={selectedCategory} onSelectCategory={setSelectedCategory} />
+        <div className="mb-6 flex flex-wrap justify-center sm:justify-start -m-1">
+          {(['all', 'active', 'completed'] as TaskFilter[]).map((f) => (
+            <button
+              key={f}
+              onClick={() => setFilter(f)}
+              className={`px-3 py-1.5 m-1 rounded-lg text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background
+                ${filter === f ? 'bg-primary text-white shadow-lg scale-105' : 'bg-surface text-textSecondary hover:bg-surface-lighter hover:text-textPrimary shadow-sm hover:shadow-md'}`}
+            >
+              {f.charAt(0).toUpperCase() + f.slice(1)}
+            </button>
+          ))}
+        </div>
         <TaskForm selectedCategory={selectedCategory} user={user} />
-        <TaskList selectedCategory={selectedCategory} user={user} />
+        <TaskList selectedCategory={selectedCategory} filter={filter} user={user} />
       </main>
 
       <footer className="text-center py-8 text-xs text-gray-500 dark:text-textMuted border-t border-gray-200 dark:border-borderDark/30">

--- a/components/tasks/TaskList.tsx
+++ b/components/tasks/TaskList.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { getTasksStream, updateTaskOrder } from '../../services/firebaseService';
-import { Task, TaskCategory, AppUser } from '../../types';
+import { Task, TaskCategory, AppUser, TaskFilter } from '../../types';
 import { TaskItem } from './TaskItem';
 import { Spinner } from '../ui/Spinner';
 import { Inbox } from 'lucide-react';
@@ -23,10 +23,11 @@ import {
 
 interface TaskListProps {
   selectedCategory: TaskCategory;
+  filter: TaskFilter;
   user: AppUser;
 }
 
-export const TaskList: React.FC<TaskListProps> = ({ selectedCategory, user }) => {
+export const TaskList: React.FC<TaskListProps> = ({ selectedCategory, filter, user }) => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -51,6 +52,7 @@ export const TaskList: React.FC<TaskListProps> = ({ selectedCategory, user }) =>
     const unsubscribe = getTasksStream(
       user.uid,
       selectedCategory,
+      filter,
       (fetchedTasks) => {
         setTasks(fetchedTasks);
         setIsLoading(false);
@@ -63,7 +65,7 @@ export const TaskList: React.FC<TaskListProps> = ({ selectedCategory, user }) =>
         unsubscribe();
       }
     };
-  }, [selectedCategory, user]);
+  }, [selectedCategory, filter, user]);
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;

--- a/services/firebaseService.ts
+++ b/services/firebaseService.ts
@@ -105,6 +105,7 @@ export const addTask = async (
 export const getTasksStream = (
   userId: string,
   category: TaskCategory,
+  filter: 'all' | 'active' | 'completed',
   callback: (tasks: Task[]) => void
 ): Unsubscribe => {
   if (!db) {
@@ -116,6 +117,8 @@ export const getTasksStream = (
     collection(db, 'tasks'),
     where('userId', '==', userId),
     where('category', '==', category),
+    ...(filter === 'active' ? [where('completed', '==', false)] : []),
+    ...(filter === 'completed' ? [where('completed', '==', true)] : []),
     orderBy('position', 'asc') // Order by the new position field
   );
 

--- a/types.ts
+++ b/types.ts
@@ -23,3 +23,5 @@ export interface Task {
 }
 
 export type AppUser = FirebaseUser | null;
+
+export type TaskFilter = 'all' | 'active' | 'completed';


### PR DESCRIPTION
## Summary
- extend tasks dashboard with filter state and controls
- apply filter to Firestore queries
- track filter in TaskList
- support `TaskFilter` type

## Testing
- `npm install`
- `npm run lint` *(fails: ESLint couldn't find configuration file)*


------
https://chatgpt.com/codex/tasks/task_e_68546806d6ec832cb2e3596cc04183bc