### PR TITLE
Add unified tasks view

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This contains everything you need to run your app locally.
 
+## Features
+
+- Central "All" tab to view tasks from every category at once.
+
 ## Run Locally
 
 **Prerequisites:**  Node.js

--- a/components/tasks/CategoryTabs.tsx
+++ b/components/tasks/CategoryTabs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TaskCategory } from '../../types';
-import { TASK_CATEGORIES } from '../../constants';
+import { CATEGORY_TABS } from '../../constants';
 
 interface CategoryTabsProps {
   selectedCategory: TaskCategory;
@@ -10,7 +10,7 @@ interface CategoryTabsProps {
 export const CategoryTabs: React.FC<CategoryTabsProps> = ({ selectedCategory, onSelectCategory }) => {
   return (
     <div className="mb-8 flex flex-wrap justify-center sm:justify-start -m-1">
-      {TASK_CATEGORIES.map((category) => (
+      {CATEGORY_TABS.map((category) => (
         <button
           key={category}
           onClick={() => onSelectCategory(category)}

--- a/components/tasks/TaskDashboard.tsx
+++ b/components/tasks/TaskDashboard.tsx
@@ -6,7 +6,6 @@ import { TaskForm } from './TaskForm';
 import { TaskList } from './TaskList';
 import { Button } from '../ui/Button';
 import { LogOut, LayoutDashboard, Moon, Sun } from 'lucide-react';
-import { TASK_CATEGORIES } from '../../constants';
 import useLocalStorageState from 'use-local-storage-state';
 
 interface TaskDashboardProps {
@@ -54,7 +53,7 @@ const Header: React.FC<{ onSignOut: () => void; userName?: string | null }> = Re
 Header.displayName = 'Header';
 
 export const TaskDashboard: React.FC<TaskDashboardProps> = ({ user }) => {
-  const [selectedCategory, setSelectedCategory] = useState<TaskCategory>(TASK_CATEGORIES[0]);
+  const [selectedCategory, setSelectedCategory] = useState<TaskCategory>(TaskCategory.ALL);
   const [filter, setFilter] = useState<TaskFilter>('all');
   const [showSignOutError, setShowSignOutError] = useState<string | null>(null);
 

--- a/components/tasks/TaskForm.tsx
+++ b/components/tasks/TaskForm.tsx
@@ -16,10 +16,15 @@ export const TaskForm: React.FC<TaskFormProps> = ({ selectedCategory, user }) =>
   const [priority, setPriority] = useState<Priority>('Medium');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const canAdd = selectedCategory !== TaskCategory.ALL;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!taskText.trim() || !user) return;
+    if (!canAdd) {
+      setError('Select a specific category tab to add tasks.');
+      return;
+    }
 
     setIsLoading(true);
     setError(null);
@@ -48,12 +53,12 @@ export const TaskForm: React.FC<TaskFormProps> = ({ selectedCategory, user }) =>
           onChange={(e) => setTaskText(e.target.value)}
           placeholder={`Add a new task for ${selectedCategory}...`}
           className="flex-grow w-full bg-transparent p-3 text-textPrimary dark:text-textPrimary placeholder-textMuted dark:placeholder-textMuted focus:outline-none focus:ring-2 focus:ring-primary rounded-lg border border-borderLight dark:border-borderDark"
-          disabled={isLoading}
+          disabled={isLoading || !canAdd}
           aria-label={`New task for ${selectedCategory}`}
         />
         <Button
           type="submit"
-          disabled={isLoading || !taskText.trim()}
+          disabled={isLoading || !taskText.trim() || !canAdd}
           variant="primary"
           size="md"
           className="w-full sm:w-auto px-5 py-3"
@@ -87,6 +92,11 @@ export const TaskForm: React.FC<TaskFormProps> = ({ selectedCategory, user }) =>
             </select>
         </div>
       </div>
+      {!canAdd && (
+        <p className="mt-3 text-sm text-textSecondary">
+          Select a category tab to add new tasks.
+        </p>
+      )}
       {error && <p className="mt-3 text-sm text-danger">{error}</p>}
     </form>
   );

--- a/constants.ts
+++ b/constants.ts
@@ -8,6 +8,11 @@ export const TASK_CATEGORIES: TaskCategory[] = [
   TaskCategory.CHORES,
 ];
 
+export const CATEGORY_TABS: TaskCategory[] = [
+  TaskCategory.ALL,
+  ...TASK_CATEGORIES,
+];
+
 // Ensure your .env file has VITE_ prefixed environment variables
 // These are typically exposed on process.env by build tools or can be accessed via import.meta.env in Vite (if typed correctly).
 // Switching to process.env for broader compatibility and to resolve current TS errors.

--- a/services/firebaseService.ts
+++ b/services/firebaseService.ts
@@ -116,7 +116,7 @@ export const getTasksStream = (
   const q = query(
     collection(db, 'tasks'),
     where('userId', '==', userId),
-    where('category', '==', category),
+    ...(category !== TaskCategory.ALL ? [where('category', '==', category)] : []),
     ...(filter === 'active' ? [where('completed', '==', false)] : []),
     ...(filter === 'completed' ? [where('completed', '==', true)] : []),
     orderBy('position', 'asc') // Order by the new position field

--- a/types.ts
+++ b/types.ts
@@ -2,6 +2,7 @@ import { Timestamp } from 'firebase/firestore';
 import { User as FirebaseUser } from 'firebase/auth';
 
 export enum TaskCategory {
+  ALL = 'All',
   WIFE = 'Wife',
   DAUGHTER = 'Daughter',
   WORK = 'Work',


### PR DESCRIPTION
## Summary
- add `ALL` category for tasks
- expose `CATEGORY_TABS` with new "All" tab
- handle cross-category display in Firestore service
- disable adding tasks while on All tab
- document new feature

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68546cd6d234832cb64a55a9abc20f58