### PR TITLE
feat: Complete UI for User API Key Management

### DIFF
--- a/components/tasks/TaskDashboard.test.tsx
+++ b/components/tasks/TaskDashboard.test.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import { TaskDashboard } from './TaskDashboard';
+import { AppUser, TaskCategory } from '../../types'; // Assuming TaskCategory might be needed for default props
+import { ApiKeyContextType } from '../../context/ApiKeyContext';
+
+// --- Mocks ---
+const mockSignOutUser = vi.fn();
+vi.mock('../../services/firebaseService', () => ({
+  signOutUser: mockSignOutUser,
+  // Add other firebase functions if TaskDashboard directly calls them, though most should be in contexts/hooks
+}));
+
+const mockUseApiKey = vi.fn();
+const mockSaveUserApiKeyToContextAndDb = vi.fn();
+const mockDeleteUserApiKeyFromContextAndDb = vi.fn();
+const mockFetchUserApiKeyState = vi.fn();
+
+vi.mock('../../context/ApiKeyContext', () => ({
+  useApiKey: mockUseApiKey,
+}));
+
+vi.mock('lucide-react', async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    LayoutDashboard: () => <div data-testid="layout-dashboard-icon" />,
+    Moon: () => <div data-testid="moon-icon" />,
+    Sun: () => <div data-testid="sun-icon" />,
+    Settings: () => <div data-testid="settings-icon" />, // For header button
+    SettingsIcon: () => <div data-testid="settings-icon" />, // Used in TaskDashboard
+    LogOut: () => <div data-testid="logout-icon" />,
+    AlertCircle: () => <div data-testid="alert-circle-icon" />,
+    CheckCircle: () => <div data-testid="check-circle-icon" />,
+    Spinner: ({size}: {size?:string}) => <div data-testid={`spinner-icon-${size || 'default'}`} />,
+  };
+});
+
+vi.mock('use-local-storage-state', () => ({
+  __esModule: true,
+  default: vi.fn(() => ['dark', vi.fn()]), // Mock theme state
+}));
+
+const mockUser: AppUser = {
+  uid: 'test-user-123',
+  email: 'test@example.com',
+  displayName: 'Test User',
+};
+
+const defaultApiKeyContextValue: ApiKeyContextType = {
+  userApiKey: null,
+  isApiKeyLoading: false,
+  apiKeyError: null,
+  fetchUserApiKeyState: mockFetchUserApiKeyState,
+  saveUserApiKeyToContextAndDb: mockSaveUserApiKeyToContextAndDb,
+  deleteUserApiKeyFromContextAndDb: mockDeleteUserApiKeyFromContextAndDb,
+};
+
+// Helper to render TaskDashboard and open settings
+async function renderDashboardAndOpenSettings(apiKeyContextOverrides: Partial<ApiKeyContextType> = {}) {
+  mockUseApiKey.mockReturnValue({ ...defaultApiKeyContextValue, ...apiKeyContextOverrides });
+
+  render(<TaskDashboard user={mockUser} />);
+
+  const settingsButton = screen.getByLabelText(/Open settings/i);
+  expect(settingsButton).toBeInTheDocument();
+  fireEvent.click(settingsButton);
+
+  // Wait for a distinctive element in the settings panel to ensure it's open
+  await screen.findByText('Gemini API Key');
+}
+
+
+describe('TaskDashboard - API Key Management', () => {
+  let mockConfirm: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseApiKey.mockReturnValue(defaultApiKeyContextValue); // Reset to default before each test
+    mockSaveUserApiKeyToContextAndDb.mockResolvedValue(undefined);
+    mockDeleteUserApiKeyFromContextAndDb.mockResolvedValue(undefined);
+    mockConfirm = vi.spyOn(window, 'confirm').mockReturnValue(true); // Default to user confirming
+  });
+
+  afterEach(() => {
+    mockConfirm.mockRestore();
+  });
+
+  test('renders API key management UI when settings panel is open', async () => {
+    await renderDashboardAndOpenSettings();
+    expect(screen.getByPlaceholderText(/Enter your Gemini API Key/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Save API Key/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Delete API Key/i })).toBeInTheDocument();
+    expect(screen.getByTestId('api-key-status')).toBeInTheDocument();
+  });
+
+  describe('Initial State Display', () => {
+    test('shows "API Key: Not Set" and disabled Delete button if no key exists', async () => {
+      await renderDashboardAndOpenSettings({ userApiKey: null, isApiKeyLoading: false });
+      expect(screen.getByTestId('api-key-status')).toHaveTextContent('API Key Status: Not Set');
+      expect(screen.getByRole('button', { name: /Delete API Key/i })).toBeDisabled();
+    });
+
+    test('shows masked API key and enabled Delete button if key exists', async () => {
+      await renderDashboardAndOpenSettings({ userApiKey: 'test-api-key', isApiKeyLoading: false });
+      expect(screen.getByTestId('api-key-status')).toHaveTextContent('API Key Status: Set (Gemini Key: ...-key)');
+      expect(screen.getByRole('button', { name: /Delete API Key/i })).toBeEnabled();
+    });
+
+    test('shows loading status if isApiKeyLoading is true', async () => {
+      await renderDashboardAndOpenSettings({ isApiKeyLoading: true });
+      expect(screen.getByTestId('api-key-status')).toHaveTextContent(/Loading/i);
+      expect(screen.getByTestId('spinner-icon-xs')).toBeInTheDocument();
+    });
+  });
+
+  test('input field updates state and enables Save button', async () => {
+    await renderDashboardAndOpenSettings();
+    const input = screen.getByPlaceholderText(/Enter your Gemini API Key/i) as HTMLInputElement;
+    const saveButton = screen.getByRole('button', { name: /Save API Key/i });
+
+    expect(saveButton).toBeDisabled(); // Initially disabled as input is empty
+    fireEvent.change(input, { target: { value: 'new-key' } });
+    expect(input.value).toBe('new-key');
+    expect(saveButton).toBeEnabled();
+  });
+
+  describe('Save API Key', () => {
+    test('calls saveUserApiKeyToContextAndDb, shows success, and clears input', async () => {
+      await renderDashboardAndOpenSettings();
+      const input = screen.getByPlaceholderText(/Enter your Gemini API Key/i) as HTMLInputElement;
+      const saveButton = screen.getByRole('button', { name: /Save API Key/i });
+
+      fireEvent.change(input, { target: { value: 'new-api-key' } });
+      fireEvent.click(saveButton);
+
+      expect(saveButton).toBeDisabled(); // Should be disabled during save
+      expect(screen.getByTestId('spinner-icon-sm')).toBeInTheDocument(); // Spinner on button
+
+      await waitFor(() => {
+        expect(mockSaveUserApiKeyToContextAndDb).toHaveBeenCalledWith(mockUser.uid, 'new-api-key');
+        expect(screen.getByText('API Key saved successfully!')).toBeInTheDocument();
+        expect(input.value).toBe(''); // Input cleared
+      });
+      expect(saveButton).toBeEnabled(); // Re-enabled
+    });
+
+    test('shows error message on save failure', async () => {
+      mockSaveUserApiKeyToContextAndDb.mockRejectedValue(new Error('Save failed miserably'));
+      await renderDashboardAndOpenSettings();
+      const input = screen.getByPlaceholderText(/Enter your Gemini API Key/i);
+      const saveButton = screen.getByRole('button', { name: /Save API Key/i });
+
+      fireEvent.change(input, { target: { value: 'fail-key' } });
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Save failed miserably')).toBeInTheDocument();
+      });
+      expect(saveButton).toBeEnabled();
+    });
+  });
+
+  describe('Delete API Key', () => {
+    test('confirms, calls deleteUserApiKeyToContextAndDb, and shows success', async () => {
+      await renderDashboardAndOpenSettings({ userApiKey: 'existing-key' });
+      const deleteButton = screen.getByRole('button', { name: /Delete API Key/i });
+
+      fireEvent.click(deleteButton);
+
+      expect(mockConfirm).toHaveBeenCalledWith("Are you sure you want to delete your API Key? This action cannot be undone.");
+      expect(deleteButton).toBeDisabled();
+      expect(screen.getByTestId('spinner-icon-sm')).toBeInTheDocument(); // Spinner on button
+
+      await waitFor(() => {
+        expect(mockDeleteUserApiKeyFromContextAndDb).toHaveBeenCalledWith(mockUser.uid);
+        expect(screen.getByText('API Key deleted successfully!')).toBeInTheDocument();
+      });
+      expect(deleteButton).toBeDisabled(); // Still disabled as userApiKey from context would now be null
+    });
+
+    test('does not call delete if user cancels confirmation', async () => {
+      mockConfirm.mockReturnValue(false);
+      await renderDashboardAndOpenSettings({ userApiKey: 'existing-key' });
+      const deleteButton = screen.getByRole('button', { name: /Delete API Key/i });
+
+      fireEvent.click(deleteButton);
+
+      expect(mockConfirm).toHaveBeenCalled();
+      expect(mockDeleteUserApiKeyFromContextAndDb).not.toHaveBeenCalled();
+      expect(deleteButton).toBeEnabled();
+    });
+
+    test('shows error message on delete failure', async () => {
+      mockDeleteUserApiKeyFromContextAndDb.mockRejectedValue(new Error('Delete failed badly'));
+      await renderDashboardAndOpenSettings({ userApiKey: 'existing-key' });
+      const deleteButton = screen.getByRole('button', { name: /Delete API Key/i });
+
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Delete failed badly')).toBeInTheDocument();
+      });
+      expect(deleteButton).toBeEnabled(); // Re-enabled (key still exists on error)
+    });
+  });
+
+  describe('Button Disabled States (Context-driven)', () => {
+    test('Save and Delete buttons are disabled if isGlobalApiKeyLoading is true', async () => {
+      await renderDashboardAndOpenSettings({ isApiKeyLoading: true, userApiKey: 'some-key' });
+      const input = screen.getByPlaceholderText(/Enter your Gemini API Key/i);
+      fireEvent.change(input, { target: { value: 'new-key' } }); // Enable save by typing
+
+      expect(screen.getByRole('button', { name: /Save API Key/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /Delete API Key/i })).toBeDisabled();
+    });
+  });
+});

--- a/components/tasks/TaskDashboard.tsx
+++ b/components/tasks/TaskDashboard.tsx
@@ -1,11 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { AppUser, TaskCategory, TaskFilter } from '../../types';
 import { signOutUser } from '../../services/firebaseService';
+import { useApiKey } from '../../context/ApiKeyContext'; // Import useApiKey
 import { CategoryTabs } from './CategoryTabs';
 import { TaskForm } from './TaskForm';
 import { TaskList } from './TaskList';
 import { Button } from '../ui/Button';
-import { LogOut, LayoutDashboard, Moon, Sun, Settings as SettingsIcon } from 'lucide-react'; // Added SettingsIcon
+import { Spinner } from '../ui/Spinner'; // Import Spinner
+import { LogOut, LayoutDashboard, Moon, Sun, Settings as SettingsIcon, AlertCircle, CheckCircle } from 'lucide-react';
 import useLocalStorageState from 'use-local-storage-state';
 
 interface TaskDashboardProps {
@@ -15,7 +17,7 @@ interface TaskDashboardProps {
 interface HeaderProps {
   onSignOut: () => void;
   userName?: string | null;
-  onToggleSettings: () => void; // New prop for settings
+  onToggleSettings: () => void;
 }
 
 const Header: React.FC<HeaderProps> = React.memo(({ onSignOut, userName, onToggleSettings }) => {
@@ -65,7 +67,24 @@ export const TaskDashboard: React.FC<TaskDashboardProps> = ({ user }) => {
   const [selectedCategory, setSelectedCategory] = useState<TaskCategory>(TaskCategory.ALL);
   const [filter, setFilter] = useState<TaskFilter>('all');
   const [showSignOutError, setShowSignOutError] = useState<string | null>(null);
-  const [showUserSettings, setShowUserSettings] = useState(false); // State for settings visibility
+  const [showUserSettings, setShowUserSettings] = useState(false);
+  const [apiKeyInputValue, setApiKeyInputValue] = useState('');
+
+  // Consume ApiKeyContext
+  const {
+    userApiKey,
+    isApiKeyLoading: isGlobalApiKeyLoading,
+    apiKeyError: globalApiKeyError,
+    saveUserApiKeyToContextAndDb,
+    deleteUserApiKeyFromContextAndDb,
+    // fetchUserApiKeyState, // Not directly called from here, but available
+  } = useApiKey();
+
+  // Local state for API key operations within settings
+  const [isSavingKey, setIsSavingKey] = useState(false);
+  const [isDeletingKey, setIsDeletingKey] = useState(false);
+  const [keyOpError, setKeyOpError] = useState<string | null>(null);
+  const [keyOpSuccessMessage, setKeyOpSuccessMessage] = useState<string | null>(null);
 
   const handleSignOut = async () => {
     setShowSignOutError(null);
@@ -77,13 +96,74 @@ export const TaskDashboard: React.FC<TaskDashboardProps> = ({ user }) => {
     }
   };
 
-  if (!user) {
-    return <p className="text-center text-textPrimary py-10">Loading user data or user not found...</p>; 
-  }
-  
   const toggleUserSettings = () => {
     setShowUserSettings(prev => !prev);
+    if (showUserSettings) { // If we are closing the settings
+        setApiKeyInputValue(''); // Clear potentially sensitive input
+        setKeyOpError(null);
+        setKeyOpSuccessMessage(null);
+    }
   };
+
+  const handleSaveApiKey = async () => {
+    if (!apiKeyInputValue.trim() || !user?.uid) return;
+
+    setIsSavingKey(true);
+    setKeyOpError(null);
+    setKeyOpSuccessMessage(null);
+    try {
+      await saveUserApiKeyToContextAndDb(user.uid, apiKeyInputValue.trim());
+      setKeyOpSuccessMessage("API Key saved successfully!");
+      setApiKeyInputValue(''); // Clear input on success
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to save API key.";
+      setKeyOpError(message);
+      console.error("Error saving API key:", error);
+    } finally {
+      setIsSavingKey(false);
+    }
+  };
+
+  const handleDeleteApiKey = async () => {
+    if (!user?.uid) return;
+
+    // Add confirmation dialog
+    const isConfirmed = window.confirm("Are you sure you want to delete your API Key? This action cannot be undone.");
+    if (!isConfirmed) {
+      return;
+    }
+
+    setIsDeletingKey(true);
+    setKeyOpError(null);
+    setKeyOpSuccessMessage(null);
+    try {
+      await deleteUserApiKeyFromContextAndDb(user.uid);
+      setKeyOpSuccessMessage("API Key deleted successfully!");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to delete API key.";
+      setKeyOpError(message);
+      console.error("Error deleting API key:", error);
+    } finally {
+      setIsDeletingKey(false);
+    }
+  };
+
+  // Effect to clear local op messages when settings are closed or global key changes
+  useEffect(() => {
+    if (!showUserSettings) {
+      setKeyOpError(null);
+      setKeyOpSuccessMessage(null);
+      // apiKeyInputValue is cleared by toggleUserSettings when closing
+    }
+  }, [showUserSettings]);
+
+  useEffect(() => {
+    // If global key status changes (e.g. fetched, or cleared by another instance),
+    // clear local messages as they might be stale.
+    setKeyOpError(null);
+    setKeyOpSuccessMessage(null);
+  }, [userApiKey, isGlobalApiKeyLoading]);
+
 
   if (!user) {
     return <p className="text-center text-textPrimary py-10">Loading user data or user not found...</p>;
@@ -94,7 +174,7 @@ export const TaskDashboard: React.FC<TaskDashboardProps> = ({ user }) => {
       <Header
         onSignOut={handleSignOut}
         userName={user.displayName || user.email}
-        onToggleSettings={toggleUserSettings} // Pass the toggle function
+        onToggleSettings={toggleUserSettings}
       />
       
       <main className="container mx-auto px-4 py-8 flex-grow">
@@ -103,13 +183,82 @@ export const TaskDashboard: React.FC<TaskDashboardProps> = ({ user }) => {
         {/* User Settings Section */}
         {showUserSettings && (
           <section className="my-6 p-6 bg-surface dark:bg-gray_800 rounded-xl shadow-lg border border-borderLight dark:border-borderDark">
-            <h2 className="text-2xl font-semibold text-textPrimary dark:text-textPrimary mb-4">
-              User Settings
-            </h2>
-            <p className="text-textSecondary dark:text-textSecondary">
-              API Key Management and other settings will be here.
-            </p>
-            {/* Future settings components will go here */}
+            <div className="flex justify-between items-center mb-6">
+              <h2 className="text-2xl font-semibold text-textPrimary dark:text-textPrimary">
+                User Settings
+              </h2>
+              {/* Optional: Add a close button for the settings section here */}
+            </div>
+
+            <div>
+              <h3 className="text-lg font-medium text-textPrimary dark:text-textPrimary mb-2">Gemini API Key</h3>
+              <p className="text-sm text-textSecondary dark:text-textSecondary mb-3">
+                Manage your Gemini API key for AI-powered features. Your key is stored securely.
+              </p>
+
+              <div className="mb-4">
+                <label htmlFor="apiKeyInput" className="block text-sm font-medium text-textSecondary dark:text-textSecondary mb-1">
+                  API Key
+                </label>
+                <input
+                  type="password"
+                  id="apiKeyInput"
+                  value={apiKeyInputValue}
+                  onChange={(e) => {
+                    setApiKeyInputValue(e.target.value);
+                    setKeyOpError(null); // Clear error when user types
+                    setKeyOpSuccessMessage(null); // Clear success message
+                  }}
+                  placeholder="Enter your Gemini API Key"
+                  className="w-full max-w-md bg-transparent p-2.5 text-textPrimary dark:text-textPrimary placeholder-textMuted dark:placeholder-textMuted focus:outline-none focus:ring-2 focus:ring-primary rounded-lg border border-borderLight dark:border-borderDark"
+                  disabled={isSavingKey || isDeletingKey || isGlobalApiKeyLoading}
+                />
+              </div>
+
+              <div className="flex items-center space-x-3 mb-4">
+                <Button
+                  variant="primary"
+                  onClick={handleSaveApiKey}
+                  disabled={!apiKeyInputValue.trim() || isSavingKey || isDeletingKey || isGlobalApiKeyLoading}
+                  leftIcon={isSavingKey ? <Spinner size="sm" /> : undefined}
+                >
+                  {isSavingKey ? 'Saving...' : 'Save API Key'}
+                </Button>
+                <Button
+                  variant="danger" // Changed from danger_outline to danger
+                  onClick={handleDeleteApiKey}
+                  disabled={!userApiKey || isDeletingKey || isSavingKey || isGlobalApiKeyLoading}
+                  leftIcon={isDeletingKey ? <Spinner size="sm" /> : undefined}
+                >
+                  {isDeletingKey ? 'Deleting...' : 'Delete API Key'}
+                </Button>
+              </div>
+
+              {/* Combined feedback area */}
+              <div className="h-10 mt-2 mb-2"> {/* Reserve space to prevent layout shifts */}
+                {keyOpError && (
+                  <p className="text-sm text-danger flex items-center">
+                    <AlertCircle size={16} className="mr-2 flex-shrink-0" /> {keyOpError}
+                  </p>
+                )}
+                {keyOpSuccessMessage && (
+                  <p className="text-sm text-success flex items-center">
+                    <CheckCircle size={16} className="mr-2 flex-shrink-0" /> {keyOpSuccessMessage}
+                  </p>
+                )}
+                {globalApiKeyError && !keyOpError && ( // Show global context error if no local op error
+                  <p className="text-sm text-danger flex items-center">
+                    <AlertCircle size={16} className="mr-2 flex-shrink-0" /> Context Error: {globalApiKeyError}
+                  </p>
+                )}
+              </div>
+
+              <div className="text-sm text-textSecondary dark:text-textMuted mb-2" data-testid="api-key-status">
+                API Key Status: {isGlobalApiKeyLoading ? <Spinner size="xs" className="inline ml-1" /> :
+                  (userApiKey ? `Set (Gemini Key: ...${userApiKey.length > 4 ? userApiKey.slice(-4) : userApiKey})` : 'Not Set')}
+              </div>
+            </div>
+            {/* Other settings can be added below */}
           </section>
         )}
 


### PR DESCRIPTION
This commit delivers the full UI implementation for managing user-specific Gemini API keys within the 'User Settings' section of the TaskDashboard.

Key changes include:

- **API Key Form**:
    - Added an input field for you to enter your Gemini API key.
    - Implemented "Save API Key" and "Delete API Key" buttons.
    - Dynamically displays the current API key status (e.g., "Not Set" or a masked version of the key like "...xxxx").
- **Context Integration**:
    - Connected the form to `ApiKeyContext` to handle saving the key to Firestore (via `saveUserApiKeyToContextAndDb`) and deleting it (via `deleteUserApiKeyFromContextAndDb`).
    - Displays loading states and success/error messages for these operations.
- **UX Refinements**:
    - Added a `window.confirm()` dialog before deleting an API key to prevent accidental deletion.
    - Styled the "Delete API Key" button with a 'danger' variant for clear visual indication.
    - Masked the display of the saved API key (showing only the last 4 characters) for better security and user experience.
- **Testing**:
    - Added comprehensive tests for the User Settings UI in `TaskDashboard.test.tsx`. These tests cover rendering, form input, save/delete operations (including success, failure, and confirmation dialog paths), display of API key status, loading indicators, and feedback messages.

You can now securely save, view the status of, and delete your personal Gemini API key through the application's interface.